### PR TITLE
pomerium auth proxy and response port unifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Pipfile
 virtual-env
 *.env
 /src/
+
+auth/k8s/secret*.yaml
+auth/tls

--- a/auth/deploy.sh
+++ b/auth/deploy.sh
@@ -1,0 +1,57 @@
+#!env bash
+
+if [[ -z $SKIP_CERTS ]]; then
+  echo "=> create ca and certs"
+  rm -rf tls/internal
+  mkdir -p tls/internal
+  go get -u github.com/google/easypki/cmd/easypki
+  export PKI_ROOT=$(pwd)/tls/internal
+  export PKI_ORGANIZATION="fld.systems"
+  export PKI_ORGANIZATIONAL_UNIT="internal"
+  export PKI_COUNTRY=GB
+  export PKI_LOCALITY="London"
+  export PKI_PROVINCE="Greater London"
+  easypki create --filename ca.incident-response.fld.systems --ca ca.incident-response.fld.systems
+  easypki create authn.incident-response.svc.cluster.local --ca-name ca.incident-response.fld.systems
+  easypki create authz.incident-response.svc.cluster.local --ca-name ca.incident-response.fld.systems
+  easypki create proxy.incident-response.svc.cluster.local --ca-name ca.incident-response.fld.systems
+  echo "=> create tls secrets"
+  kubectl -n incident-response create secret tls authn-tls \
+    --cert=tls/internal/ca.incident-response.fld.systems/certs/authn.incident-response.svc.cluster.local.crt \
+    --key=tls/internal/ca.incident-response.fld.systems/keys/authn.incident-response.svc.cluster.local.key --dry-run -o yaml >k8s/secret-authn-tls.yaml
+  kubectl -n incident-response create secret tls authz-tls \
+    --cert=tls/internal/ca.incident-response.fld.systems/certs/authz.incident-response.svc.cluster.local.crt \
+    --key=tls/internal/ca.incident-response.fld.systems/keys/authz.incident-response.svc.cluster.local.key --dry-run -o yaml >k8s/secret-authz-tls.yaml
+  kubectl -n incident-response create secret tls proxy-tls \
+    --cert=tls/internal/ca.incident-response.fld.systems/certs/proxy.incident-response.svc.cluster.local.crt \
+    --key=tls/internal/ca.incident-response.fld.systems/keys/proxy.incident-response.svc.cluster.local.key --dry-run -o yaml >k8s/secret-proxy-tls.yaml
+  kubectl -n incident-response create secret generic ca-tls \
+    --from-file="ca.crt"="tls/internal/ca.incident-response.fld.systems/certs/ca.incident-response.fld.systems.crt" --dry-run -o yaml >k8s/secret-ca-tls.yaml
+fi
+
+echo "=> clone response-secrets"
+git clone git@github.com:Feeld/response-secrets.git _response-secrets
+
+echo "=> decrypt response-secrets repo"
+(
+  cd _response-secrets
+  git-crypt unlock
+)
+
+echo "=> copy secret.yaml"
+cp _response-secrets/k8s/secret.yaml k8s/
+
+echo "=> remove cloned repo"
+rm -rf _response-secrets
+
+echo "=> create incident-response namespace"
+kubectl create namespace incident-response
+
+echo "=> delete old ingress"
+kubectl -n incident-response delete ingress response
+
+echo "=> delete old nodeport service"
+kubectl -n incident-response delete service response
+
+echo "=> deploy manifests"
+kubectl apply -n incident-response -f k8s

--- a/auth/k8s/authn-deployment.yaml
+++ b/auth/k8s/authn-deployment.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: authn
+  name: authn
+  namespace: incident-response
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pomerium
+      app.kubernetes.io/component: authn
+  template:
+    metadata:
+      annotations: {}
+      # checksum/config: 52133ddfcd583280388a8bbfb67a417b6b660f75bc63ec1b01beec811d4498ef
+      # checksum/secret: 70cfeae0222c88a24e261ab0355dd4ea92dde47e0780f9d6b554e144580d1650
+      labels:
+        app.kubernetes.io/name: pomerium
+        app.kubernetes.io/component: authn
+    spec:
+      containers:
+        - name: pomerium
+          image: pomerium/pomerium:v0.4.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/pomerium/config.yaml
+          env:
+            - name: SERVICES
+              value: authenticate
+            - name: AUTHENTICATE_SERVICE_URL
+              value: https://incidents-auth.fld.systems
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: cookie-secret
+            - name: SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: shared-secret
+            - name: IDP_PROVIDER
+              value: oidc
+            - name: IDP_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: idp-client-id
+            - name: IDP_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: idp-client-secret
+            - name: IDP_PROVIDER_URL
+              value:
+            - name: CERTIFICATE_FILE
+              value: "/pomerium/cert.pem"
+            - name: CERTIFICATE_KEY_FILE
+              value: "/pomerium/privkey.pem"
+            - name: CERTIFICATE_AUTHORITY_FILE
+              value: "/pomerium/ca.pem"
+          ports:
+            - containerPort: 443
+              name: https
+              protocol: TCP
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: https
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: https
+              scheme: HTTPS
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/pomerium/
+              name: config
+            - mountPath: /pomerium/cert.pem
+              name: service-tls
+              subPath: tls.crt
+            - mountPath: /pomerium/privkey.pem
+              name: service-tls
+              subPath: tls.key
+            - mountPath: /pomerium/ca.pem
+              name: ca-tls
+              subPath: ca.crt
+      volumes:
+        - name: config
+          configMap:
+            name: auth-proxy-config
+        - name: service-tls
+          secret:
+            secretName: authn-tls
+        - name: ca-tls
+          secret:
+            secretName: ca-tls

--- a/auth/k8s/authn-service.yaml
+++ b/auth/k8s/authn-service.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authn
+  namespace: incident-response
+  labels:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: authn
+  annotations:
+    cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+spec:
+  type: NodePort
+  ports:
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: authn

--- a/auth/k8s/authz-deployment.yaml
+++ b/auth/k8s/authz-deployment.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: authz
+  name: authz
+  namespace: incident-response
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pomerium
+      app.kubernetes.io/component: authz
+  template:
+    metadata:
+      annotations: {}
+      # checksum/config: 52133ddfcd583280388a8bbfb67a417b6b660f75bc63ec1b01beec811d4498ef
+      # checksum/secret: 70cfeae0222c88a24e261ab0355dd4ea92dde47e0780f9d6b554e144580d1650
+      labels:
+        app.kubernetes.io/name: pomerium
+        app.kubernetes.io/component: authz
+    spec:
+      containers:
+        - name: pomerium
+          image: pomerium/pomerium:v0.4.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/pomerium/config.yaml
+          env:
+            - name: SERVICES
+              value: authorize
+            - name: SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: shared-secret
+            - name: CERTIFICATE_FILE
+              value: "/pomerium/cert.pem"
+            - name: CERTIFICATE_KEY_FILE
+              value: "/pomerium/privkey.pem"
+            - name: CERTIFICATE_AUTHORITY_FILE
+              value: "/pomerium/ca.pem"
+          ports:
+            - containerPort: 443
+              name: https
+              protocol: TCP
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: https
+              # initialDelaySeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/pomerium/
+              name: config
+            - mountPath: /pomerium/cert.pem
+              name: service-tls
+              subPath: tls.crt
+            - mountPath: /pomerium/privkey.pem
+              name: service-tls
+              subPath: tls.key
+            - mountPath: /pomerium/ca.pem
+              name: ca-tls
+              subPath: ca.crt
+      volumes:
+        - name: config
+          configMap:
+            name: auth-proxy-config
+        - name: service-tls
+          secret:
+            secretName: authz-tls
+        - name: ca-tls
+          secret:
+            secretName: ca-tls

--- a/auth/k8s/authz-service.yaml
+++ b/auth/k8s/authz-service.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authz
+  namespace: incident-response
+  labels:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: authz
+  annotations:
+    cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: authz

--- a/auth/k8s/config-unifier.yaml
+++ b/auth/k8s/config-unifier.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  Caddyfile: |+
+    :80
+    tls off
+    proxy /static response.incident-response.svc.cluster.local:8080
+    proxy / response.incident-response.svc.cluster.local:8000
+
+kind: ConfigMap
+metadata:
+  name: unifier-config
+  namespace: incident-response

--- a/auth/k8s/config.yaml
+++ b/auth/k8s/config.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-proxy-config
+  namespace: incident-response
+data:
+  config.yaml: |
+    idp_provider: google
+    idp_provider_url: https://accounts.google.com
+    idp_scopes:
+      - openid
+      - email
+      - profile
+    policy:
+      - from: https://incidents.fld.systems
+        to: http://response-unifier.incident-response.svc.cluster.local
+        cors_allow_preflight: true
+        timeout: 30s
+        allowed_domains:
+          - feeld.co

--- a/auth/k8s/ingress.yaml
+++ b/auth/k8s/ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    app.kubernetes.io/component: http-auth-service
+    app.kubernetes.io/instance: response
+    app.kubernetes.io/name: response
+    app.kubernetes.io/part-of: response
+    certmanager.k8s.io/cluster-issuer: fld-letsencrypt-prd
+    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  labels:
+    app.kubernetes.io/instance: response
+    app.kubernetes.io/name: response
+  name: response-authed
+  namespace: incident-response
+spec:
+  rules:
+    - host: incidents.fld.systems
+      http:
+        paths:
+          - backend:
+              serviceName: proxy
+              servicePort: https
+    - host: incidents-auth.fld.systems
+      http:
+        paths:
+          - backend:
+              serviceName: authn
+              servicePort: https
+  tls:
+    - hosts:
+        - incidents.fld.systems
+        - incidents-auth.fld.systems
+      secretName: tls-cert-incidents

--- a/auth/k8s/proxy-deployment.yaml
+++ b/auth/k8s/proxy-deployment.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: proxy
+  name: proxy
+  namespace: incident-response
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pomerium
+      app.kubernetes.io/component: proxy
+  template:
+    metadata:
+      annotations: {}
+      # checksum/config: 52133ddfcd583280388a8bbfb67a417b6b660f75bc63ec1b01beec811d4498ef
+      # checksum/secret: 70cfeae0222c88a24e261ab0355dd4ea92dde47e0780f9d6b554e144580d1650
+      labels:
+        app.kubernetes.io/name: pomerium
+        app.kubernetes.io/component: proxy
+    spec:
+      containers:
+        - name: pomerium
+          image: pomerium/pomerium:v0.4.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/pomerium/config.yaml
+          env:
+            - name: SERVICES
+              value: proxy
+            - name: AUTHENTICATE_SERVICE_URL
+              value: https://incidents-auth.fld.systems
+            - name: AUTHORIZE_SERVICE_URL
+              value: https://authz.incident-response.svc.cluster.local
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: cookie-secret
+            - name: SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: shared-secret
+            - name: CERTIFICATE_FILE
+              value: "/pomerium/cert.pem"
+            - name: CERTIFICATE_KEY_FILE
+              value: "/pomerium/privkey.pem"
+            - name: CERTIFICATE_AUTHORITY_FILE
+              value: "/pomerium/ca.pem"
+          ports:
+            - containerPort: 443
+              name: https
+              protocol: TCP
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: https
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: https
+              scheme: HTTPS
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/pomerium/
+              name: config
+            - mountPath: /pomerium/cert.pem
+              name: service-tls
+              subPath: tls.crt
+            - mountPath: /pomerium/privkey.pem
+              name: service-tls
+              subPath: tls.key
+            - mountPath: /pomerium/ca.pem
+              name: ca-tls
+              subPath: ca.crt
+      volumes:
+        - name: config
+          configMap:
+            name: auth-proxy-config
+        - name: service-tls
+          secret:
+            secretName: proxy-tls
+        - name: ca-tls
+          secret:
+            secretName: ca-tls

--- a/auth/k8s/proxy-service.yaml
+++ b/auth/k8s/proxy-service.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy
+  namespace: incident-response
+  labels:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: proxy
+  annotations:
+    cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+spec:
+  type: NodePort
+  ports:
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: pomerium
+    app.kubernetes.io/component: proxy

--- a/auth/k8s/response-service-clusterip.yaml
+++ b/auth/k8s/response-service-clusterip.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: response
+    app.kubernetes.io/name: response
+    helm.sh/chart: response-0.1.0
+  name: response
+  namespace: incident-response
+spec:
+  ports:
+    - name: static
+      port: 8080
+      protocol: TCP
+      targetPort: 80
+    - name: response
+      port: 8000
+      protocol: TCP
+      targetPort: 8000
+  selector:
+    app.kubernetes.io/instance: response
+    app.kubernetes.io/name: response
+  type: ClusterIP

--- a/auth/k8s/unifier-deployment.yaml
+++ b/auth/k8s/unifier-deployment.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: response-unifier
+  namespace: incident-response
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: caddy
+      app.kubernetes.io/component: web
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: caddy
+        app.kubernetes.io/component: web
+    spec:
+      containers:
+        - name: caddy
+          image: gcr.io/fld-staging/response-unifier:1.0.0
+          ports:
+            - containerPort: 80
+              name: http
+          volumeMounts:
+            - mountPath: /conf/
+              name: conf
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+      volumes:
+        - name: conf
+          configMap:
+            name: unifier-config

--- a/auth/k8s/unifier-service.yaml
+++ b/auth/k8s/unifier-service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: response-unifier
+  namespace: incident-response
+  labels:
+    app.kubernetes.io/name: caddy
+    app.kubernetes.io/component: web
+  annotations:
+    cloud.google.com/app-protocols: '{"http":"HTTP"}'
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: caddy
+    app.kubernetes.io/component: web

--- a/ingress-response.yaml
+++ b/ingress-response.yaml
@@ -1,0 +1,59 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    app.kubernetes.io/component: http-service
+    app.kubernetes.io/instance: response
+    app.kubernetes.io/managed-by: response
+    app.kubernetes.io/name: response
+    app.kubernetes.io/part-of: response
+    certmanager.k8s.io/cluster-issuer: fld-letsencrypt-prd
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{"app.kubernetes.io/component":"http-service","app.kubernetes.io/instance":"response","app.kubernetes.io/managed-by":"response","app.kubernetes.io/name":"response","app.kubernetes.io/part-of":"response","certmanager.k8s.io/cluster-issuer":"fld-letsencrypt-prd","kubernetes.io/ingress.allow-http":"false","kubernetes.io/ingress.class":"nginx","kubernetes.io/tls-acme":"true"},"labels":{"app.kubernetes.io/instance":"response","app.kubernetes.io/name":"response","helm.sh/chart":"response-0.1.0"},"name":"response","namespace":"incident-response"},"spec":{"rules":[{"host":"incidents-with-auth.fld.systems","http":{"paths":[{"backend":{"serviceName":"proxy","servicePort":"https"},"paths":null}]}},{"host":"incidents-auth.fld.systems","http":{"paths":[{"backend":{"serviceName":"authn","servicePort":"https"},"paths":null}]}},{"host":"incidents.fld.systems","http":{"paths":[{"backend":{"serviceName":"response","servicePort":8080},"path":"/static"},{"backend":{"serviceName":"response","servicePort":8000},"path":"/"}]}},{"host":"incidents.fld.services","http":{"paths":[{"backend":{"serviceName":"response","servicePort":8080},"path":"/static"},{"backend":{"serviceName":"response","servicePort":8000},"path":"/"}]}}],"tls":[{"hosts":["incidents.fld.systems","incidents.fld.services","incidents-auth.fld.systems","incidents-with-auth.fld.systems"],"secretName":"tls-cert-incidents"}]}}
+    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  creationTimestamp: "2019-07-11T22:03:41Z"
+  generation: 3
+  labels:
+    app.kubernetes.io/instance: response
+    app.kubernetes.io/name: response
+    helm.sh/chart: response-0.1.0
+  name: response
+  namespace: incident-response
+  resourceVersion: "42334574"
+  selfLink: /apis/extensions/v1beta1/namespaces/incident-response/ingresses/response
+  uid: be2f91d2-a427-11e9-9d55-4201a9100039
+spec:
+  rules:
+  - host: incidents.fld.systems
+    http:
+      paths:
+      - backend:
+          serviceName: response
+          servicePort: 8080
+        path: /static
+      - backend:
+          serviceName: response
+          servicePort: 8000
+        path: /
+  - host: incidents.fld.services
+    http:
+      paths:
+      - backend:
+          serviceName: response
+          servicePort: 8080
+        path: /static
+      - backend:
+          serviceName: response
+          servicePort: 8000
+        path: /
+  tls:
+  - hosts:
+    - incidents.fld.systems
+    - incidents.fld.services
+    secretName: tls-cert-incidents
+status:
+  loadBalancer:
+    ingress:
+    - {}

--- a/response-unifier/Caddyfile
+++ b/response-unifier/Caddyfile
@@ -1,0 +1,4 @@
+tls off
+proxy / response.incident-response.svc.cluster.local:8000
+proxy /static response.incident-response.svc.cluster.local:8080
+

--- a/response-unifier/Dockerfile
+++ b/response-unifier/Dockerfile
@@ -1,0 +1,31 @@
+# caddy builder
+FROM abiosoft/caddy:builder as builder
+ARG version="1.0.3"
+ARG plugins="realip"
+ARG enable_telemetry="true"
+RUN go get -v github.com/abiosoft/parent
+RUN VERSION=${version} PLUGINS=${plugins} ENABLE_TELEMETRY=${enable_telemetry} /bin/sh /usr/bin/builder.sh
+# main container
+FROM alpine:3.10
+LABEL maintainer "Dave Williams <dave@dave.io>"
+ARG version="1.0.3"
+LABEL caddy_version="$version"
+ENV ACME_AGREE="true"
+ENV ENABLE_TELEMETRY="$enable_telemetry"
+RUN apk add --no-cache \
+  ca-certificates \
+  curl \
+  mailcap \
+  openssh-client \
+  tar \
+  tzdata
+RUN mkdir /conf
+COPY --from=builder /install/caddy /usr/bin/caddy
+RUN /usr/bin/caddy -version
+RUN /usr/bin/caddy -plugins
+EXPOSE 80 443 2015
+VOLUME /conf
+WORKDIR /srv
+COPY --from=builder /go/bin/parent /bin/parent
+ENTRYPOINT ["/bin/parent", "caddy"]
+CMD ["--conf", "/conf/Caddyfile", "--log", "stdout", "--agree=$ACME_AGREE"]


### PR DESCRIPTION
After the Helm chart is deployed -

```
cd auth/
./deploy.sh
```

Don't run the script from anywhere but the `auth/` directory. Adventures may ensue.

There's also a new container in `response-unifier/` which is a very simple and lightweight homebrew Caddy instance. All it does is proxy Response's two ports (static and API) into a single port, as required by the authentication proxy.
